### PR TITLE
Added missing assemblies to proj files

### DIFF
--- a/micromachine/Micromachine.fsproj
+++ b/micromachine/Micromachine.fsproj
@@ -34,6 +34,9 @@
     <DocumentationFile>bin\Release\micromachine.XML</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="FSharp.Data.DesignTime">
+      <HintPath>..\packages\FSharp.Data\lib\net40\FSharp.Data.DesignTime.dll</HintPath>
+    </Reference>
     <Reference Include="mscorlib" />
     <Reference Include="FSharp.Core, Version=$(TargetFSharpCoreVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <Private>True</Private>

--- a/survey/Survey.fsproj
+++ b/survey/Survey.fsproj
@@ -34,6 +34,9 @@
     <DocumentationFile>bin\Release\survey.XML</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="FSharp.Data.DesignTime">
+      <HintPath>..\packages\FSharp.Data\lib\net40\FSharp.Data.DesignTime.dll</HintPath>
+    </Reference>
     <Reference Include="mscorlib" />
     <Reference Include="FSharp.Core, Version=$(TargetFSharpCoreVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <Private>True</Private>


### PR DESCRIPTION
FSharp.Data.DesignTime was missing from the Survey proj file, so wasn't in `bin/release`.

This is why `#load "../refs.fsx"` fails in `AsyncSeq.fsx`